### PR TITLE
Fix CI license check paths

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             cli/package-lock.json
-            agenticflow-memory-mcp/package-lock.json
+            packages/*/package-lock.json
 
       - name: Check CLI Licenses
         run: |
@@ -34,13 +34,46 @@ jobs:
             exit 1
           fi
 
+      - name: Check Semantic Search Core Licenses
+        run: |
+          cd packages/mcp-semantic-search-core
+          npm ci
+          VIOLATIONS=$(npx license-checker --production --json --excludePrivatePackages | jq -r 'to_entries[] | select(.value.licenses | IN("MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "0BSD", "LGPL-3.0-or-later", "BlueOak-1.0.0", "(MIT OR CC0-1.0)") | not) | select(.key | (contains("@chroma-core/") or contains("flatbuffers") or contains("@agenticflow/")) | not) | "\(.key): \(.value.licenses)"')
+          if [ -n "$VIOLATIONS" ]; then
+            echo "License violations found in Semantic Search Core MCP:"
+            echo "$VIOLATIONS"
+            exit 1
+          fi
+
+      - name: Check Embedding Providers Licenses
+        run: |
+          cd packages/mcp-embedding-providers
+          npm ci
+          VIOLATIONS=$(npx license-checker --production --json --excludePrivatePackages | jq -r 'to_entries[] | select(.value.licenses | IN("MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "0BSD", "LGPL-3.0-or-later", "BlueOak-1.0.0", "(MIT OR CC0-1.0)") | not) | select(.key | (contains("@chroma-core/") or contains("flatbuffers") or contains("@agenticflow/")) | not) | "\(.key): \(.value.licenses)"')
+          if [ -n "$VIOLATIONS" ]; then
+            echo "License violations found in Embedding Providers MCP:"
+            echo "$VIOLATIONS"
+            exit 1
+          fi
+
       - name: Check Memory MCP Licenses
         run: |
-          cd agenticflow-memory-mcp
+          cd packages/mcp-memory
           npm ci
-          VIOLATIONS=$(npx license-checker --production --json --excludePrivatePackages | jq -r 'to_entries[] | select(.value.licenses | IN("MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "0BSD", "LGPL-3.0-or-later", "BlueOak-1.0.0", "(MIT OR CC0-1.0)") | not) | select(.key | (contains("@chroma-core/") or contains("flatbuffers") or contains("agenticflow-memory-mcp")) | not) | "\(.key): \(.value.licenses)"')
+          VIOLATIONS=$(npx license-checker --production --json --excludePrivatePackages | jq -r 'to_entries[] | select(.value.licenses | IN("MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "0BSD", "LGPL-3.0-or-later", "BlueOak-1.0.0", "(MIT OR CC0-1.0)") | not) | select(.key | (contains("@chroma-core/") or contains("flatbuffers") or contains("@agenticflow/")) | not) | "\(.key): \(.value.licenses)"')
           if [ -n "$VIOLATIONS" ]; then
             echo "License violations found in Memory MCP:"
+            echo "$VIOLATIONS"
+            exit 1
+          fi
+
+      - name: Check Sync Controller MCP Licenses
+        run: |
+          cd packages/mcp-sync-controller
+          npm ci
+          VIOLATIONS=$(npx license-checker --production --json --excludePrivatePackages | jq -r 'to_entries[] | select(.value.licenses | IN("MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "0BSD", "LGPL-3.0-or-later", "BlueOak-1.0.0", "(MIT OR CC0-1.0)") | not) | select(.key | (contains("@chroma-core/") or contains("flatbuffers") or contains("@agenticflow/")) | not) | "\(.key): \(.value.licenses)"')
+          if [ -n "$VIOLATIONS" ]; then
+            echo "License violations found in Sync Controller MCP:"
             echo "$VIOLATIONS"
             exit 1
           fi

--- a/licenses-temp.json
+++ b/licenses-temp.json
@@ -1,0 +1,38 @@
+{
+  "@agenticflow/mcp-sync-controller@1.0.0": {
+    "licenses": "Custom: http://127.0.0.1",
+    "path": "/app/packages/mcp-sync-controller",
+    "licenseFile": "/app/packages/mcp-sync-controller/README.md"
+  },
+  "chokidar@3.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/paulmillr/chokidar",
+    "publisher": "Paul Miller",
+    "url": "https://paulmillr.com",
+    "path": "/app/packages/mcp-sync-controller/node_modules/chokidar",
+    "licenseFile": "/app/packages/mcp-sync-controller/node_modules/chokidar/LICENSE"
+  },
+  "dotenv@16.6.1": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/motdotla/dotenv",
+    "path": "/app/packages/mcp-sync-controller/node_modules/dotenv",
+    "licenseFile": "/app/packages/mcp-sync-controller/node_modules/dotenv/LICENSE"
+  },
+  "picomatch@2.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/micromatch/picomatch",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/app/packages/mcp-sync-controller/node_modules/picomatch",
+    "licenseFile": "/app/packages/mcp-sync-controller/node_modules/picomatch/LICENSE"
+  },
+  "readdirp@3.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/paulmillr/readdirp",
+    "publisher": "Thorsten Lorenz",
+    "email": "thlorenz@gmx.de",
+    "url": "thlorenz.com",
+    "path": "/app/packages/mcp-sync-controller/node_modules/readdirp",
+    "licenseFile": "/app/packages/mcp-sync-controller/node_modules/readdirp/LICENSE"
+  }
+}


### PR DESCRIPTION
Fixed paths in the Github Actions license check workflow to correctly reflect the new monorepo structure. Additionally included all monorepo packages in the check to ensure comprehensive coverage.

---
*PR created automatically by Jules for task [12380266714481287385](https://jules.google.com/task/12380266714481287385) started by @thomasvanwijk*